### PR TITLE
fix(python): remove bind mounts causing issue with Podman

### DIFF
--- a/v1/python-starter/python.dockerfile
+++ b/v1/python-starter/python.dockerfile
@@ -6,9 +6,8 @@ ENV HANDLER=${HANDLER}
 
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy PYTHONPATH=.
 WORKDIR /app
+COPY uv.lock pyproject.toml /app/
 RUN --mount=type=cache,target=/root/.cache/uv \
-  --mount=type=bind,source=uv.lock,target=uv.lock \
-  --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
   uv sync --frozen --no-install-project --no-dev --no-python-downloads
 COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -22,7 +21,7 @@ ARG HANDLER
 ENV HANDLER=${HANDLER} PYTHONPATH=.
 
 # Copy the application from the builder
-COPY --from=builder --chown=app:app /app /app
+COPY --from=builder /app /app
 WORKDIR /app
 
 # Place executables in the environment at the front of the path


### PR DESCRIPTION
Resolves 'permission denied' errors that occur in [Podman](https://github.com/containers/podman/issues/15423) with `--mount=type=bind` mounts. Another solution is add `,z` to these mounts, but that breaks in docker.